### PR TITLE
Added support to set extra sidecars and extra role permissions.

### DIFF
--- a/charts/cloudflare-operator/Chart.yaml
+++ b/charts/cloudflare-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudflare-operator
 description: Helm chart for Cloudflare Operator
 type: application
-version: 0.3.3
+version: 0.3.4
 appVersion: "v0.3.3"
 keywords:
   - cloudflare

--- a/charts/cloudflare-operator/Chart.yaml
+++ b/charts/cloudflare-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cloudflare-operator
 description: Helm chart for Cloudflare Operator
 type: application
-version: 0.3.4
+version: 0.3.5
 appVersion: "v0.3.3"
 keywords:
   - cloudflare

--- a/charts/cloudflare-operator/README.md
+++ b/charts/cloudflare-operator/README.md
@@ -48,45 +48,6 @@ The following tables lists the configurable parameters of cloudflare-operator he
 
 For a detailed uninstall guide, see the [cloudflare-operator documentation](https://docs.cf.containeroo.ch/installation/#uninstalling-with-helm).
 
-## Update IP from service.status.loadBalancer.ingress.[0].ip
-Add kubectl sidecar container to be able to send requests into kubernetes API.
-```yaml
-sidecars:
-  - name: proxy
-    image: bitnami/kubectl
-    args: ["proxy","--port=8858"]
-```
-
-Add additional permissions for this sidecar to be able to get service resource.
-
-```yaml
-clusterRole:
-  extraRules:
-  - apiGroups:
-    - ""
-    resources:
-    - services
-    verbs:
-    - get
-    - list
-```
-
-Now add IP object
-
-```yaml
----
-apiVersion: cf.containeroo.ch/v1beta1
-kind: IP
-metadata:
-  name: ingress-ip
-spec:
-  type: dynamic
-  ipSources:
-    - url: localhost:8858/api/v1/namespaces/ingress-nginx/services/ingress-nginx
-      responseJSONPath: '{.status.loadBalancer.ingress.[0].ip}'
-  interval: 5m
-```
-
 ## Upgrade Notes
 
 ## From v0.0.x to v0.1.0

--- a/charts/cloudflare-operator/templates/deployment.yaml
+++ b/charts/cloudflare-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.sidecars }}
+          {{- toYaml .Values.sidecars | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cloudflare-operator/templates/rbac.yaml
+++ b/charts/cloudflare-operator/templates/rbac.yaml
@@ -126,6 +126,9 @@ rules:
   - get
   - list
   - watch
+{{ if .Values.clusterRole.extraRules }}
+  {{- toYaml .Values.clusterRole.extraRules }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/cloudflare-operator/values.yaml
+++ b/charts/cloudflare-operator/values.yaml
@@ -12,6 +12,18 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Add additional sidecar containers to the operator pod
+# e.g:
+# sidecars:
+#   - name: your-image-name
+#     image: your-image
+#     imagePullPolicy: Always
+#     ports:
+#       - name: portname
+#         containerPort: 1234
+#
+sidecars: []
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -27,6 +39,19 @@ clusterRole:
   # The name of a cluster role to bind to; if not set and create is
   # true, a name based on fullname is generated
   name: ""
+  # Additional rules to be included in the role
+  # e.g:
+  # extraRules:
+  # - apiGroups:
+  #   - ""
+  #   resources:
+  #   - services
+  #   verbs:
+  #   - get
+  #   - list
+  #   - watch
+  #
+  extraRules: []
 
 podAnnotations: {}
 


### PR DESCRIPTION
This PR provides support for using operator service account to get IPs from other Kubernetes objects, such as services or Istio gateways.
WDYT?